### PR TITLE
add missing waitpid() in version()

### DIFF
--- a/lib/GnuPG/Interface.pm
+++ b/lib/GnuPG/Interface.pm
@@ -767,9 +767,12 @@ sub version {
 
     my $out = IO::Handle->new;
     my $handles = GnuPG::Handles->new( stdout => $out );
-    $self->wrap_call( commands => [ '--version' ], handles => $handles );
+    my $pid = $self->wrap_call( commands => [ '--version' ], handles => $handles );
     my $line = $out->getline;
     $line =~ /(\d+\.\d+\.\d+)/;
+
+    waitpid $pid, 0;
+
     return $1;
 }
 

--- a/t/version.t
+++ b/t/version.t
@@ -1,0 +1,14 @@
+use strict;
+
+use lib './t';
+use MyTest;
+use MyTestSpecific;
+
+TEST
+{
+    reset_handles();
+
+    my $version = $gnupg->version;
+
+    return $gnupg->version =~ /^[\d.]+$/;
+};


### PR DESCRIPTION
version() is missing a waitpid() call so it leaves a zombie process.