### PR TITLE
Make $gnupg->call('foo') update the internal GnuPG version number.

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -50,10 +50,13 @@ t/sign.t
 t/sign_and_encrypt.t
 t/UserId.t
 t/verify.t
+t/version_updates.t
 t/wrap_call.t
 t/zzz_cleanup.t
 test/encrypted.1.gpg
 test/encrypted.2.gpg
+test/fake-gpg-v1
+test/fake-gpg-v2
 test/fake-pinentry.pl
 test/gpg.conf
 test/key.1.asc

--- a/lib/GnuPG/Interface.pm
+++ b/lib/GnuPG/Interface.pm
@@ -30,11 +30,18 @@ use GnuPG::Handles;
 
 $VERSION = '1.00';
 
-has $_ => (
+has passphrase => (
     isa     => 'Any',
     is      => 'rw',
-    clearer => 'clear_' . $_,
-) for qw(call passphrase);
+    clearer => 'clear_passphrase',
+);
+
+has call => (
+    isa     => 'Any',
+    is      => 'rw',
+    trigger => 1,
+    clearer => 'clear_call',
+);
 
 # NB: GnuPG versions
 #
@@ -81,6 +88,12 @@ struct(
         parent_is_source => '$', name_shows_dup => '$',
     }
 );
+
+# Update version if "call" is updated
+sub _trigger_call {
+    my ($self, $gpg) = @_;
+    $self->_set_version($self->_version());
+}
 
 #################################################################
 # real worker functions

--- a/t/Interface.t
+++ b/t/Interface.t
@@ -24,6 +24,12 @@ TEST
 # deprecation test
 TEST
 {
-    $gnupg->gnupg_call( $v2 );
+    # We wrap the next call in an "eval" because
+    # setting call tries to execute the program
+    # to figure out the version, which will
+    # fail if "gnupg" is not found... but we
+    # don't care about the version for the
+    # purpose of this test.
+    eval { $gnupg->gnupg_call( $v2 ); };
     $gnupg->call() eq $v2;
 };

--- a/t/Interface.t
+++ b/t/Interface.t
@@ -10,8 +10,8 @@ use MyTest;
 
 use GnuPG::Interface;
 
-my $v1 = 'gpg';
-my $v2 = 'gnupg';
+my $v1 = './test/fake-gpg-v1';
+my $v2 = './test/fake-gpg-v2';
 
 my $gnupg = GnuPG::Interface->new( call => $v1 );
 

--- a/t/version_updates.t
+++ b/t/version_updates.t
@@ -1,0 +1,33 @@
+#!/usr/bin/perl -w
+#
+#  $Id: wrap_call.t,v 1.1 2001/05/03 07:32:34 ftobin Exp $
+#
+
+use strict;
+
+use lib './t';
+use MyTest;
+use MyTestSpecific;
+
+TEST
+{
+    my $gpg = GnuPG::Interface->new(call => './test/fake-gpg-v1');
+    return ($gpg->version() eq '1.4.23');
+};
+
+
+TEST
+{
+    my $gpg = GnuPG::Interface->new(call => './test/fake-gpg-v2');
+    return ($gpg->version() eq '2.2.12');
+};
+
+TEST
+{
+    my $gpg = GnuPG::Interface->new(call => './test/fake-gpg-v1');
+    my $v1 = $gpg->version();
+    $gpg->call('./test/fake-gpg-v2');
+    my $v2 = $gpg->version();
+
+    return ($v1 eq '1.4.23' && $v2 eq '2.2.12');
+}

--- a/test/fake-gpg-v1
+++ b/test/fake-gpg-v1
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo 'gpg (GnuPG) 1.4.23'

--- a/test/fake-gpg-v2
+++ b/test/fake-gpg-v2
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo 'gpg (GnuPG) 2.2.12'


### PR DESCRIPTION
Before, if you set the GPG executable using call(), and the
version was different from the version used in the constructor,
GnuPG::Interface would pass the wrong options to the program.

This patch makes sure the executable and the version number
are always in sync.