### PR TITLE
Update tests for gpg 2.3.8+

### DIFF
--- a/t/get_public_keys.t
+++ b/t/get_public_keys.t
@@ -181,7 +181,7 @@ TEST
         hex_id                   => 'ADB99D9C2E854A6B',
         creation_date            => 949813119,
         creation_date_string     => '2000-02-06',
-        usage_flags              => 'e',
+        usage_flags              => $gnupg->cmp_version($gnupg->version, '2.3.8') >= 0 ? 'er' : 'e',
         pubkey_data              => $subkey_pub_data,
       );
 

--- a/t/get_secret_keys.t
+++ b/t/get_secret_keys.t
@@ -87,7 +87,7 @@ TEST
         hex_id                   => 'ADB99D9C2E854A6B',
         creation_date            => 949813119,
         creation_date_string     => '2000-02-06',
-        usage_flags              => 'e',
+        usage_flags              => $gnupg->cmp_version($gnupg->version, '2.3.8') >= 0 ? 'er' : 'e',
         pubkey_data              => $subkey_pub_data,
       };
 

--- a/t/list_secret_keys.t
+++ b/t/list_secret_keys.t
@@ -45,17 +45,20 @@ TEST
 TEST
 {
     my $keylist;
-    if ($gnupg->cmp_version($gnupg->version, '2.1') < 0) {
-	$keylist = '0';
+    if ( $gnupg->cmp_version( $gnupg->version, '2.1' ) < 0 ) {
+        $keylist = '0';
+    }
+    elsif ( $gnupg->cmp_version( $gnupg->version, '2.1.11' ) <= 0 ) {
+        $keylist = '1';
+    }
+    elsif ( $gnupg->cmp_version( $gnupg->version, '2.3.8' ) < 0 ) {
+        $keylist = '2.2';
     }
     else {
-	if ($gnupg->cmp_version($gnupg->version, '2.1.11') <= 0) {
-	    $keylist = '1';
-	}
-	else {
-	    $keylist = '2';
-	}
+        $keylist = '2';
     }
+
+
     my @files_to_test = ( 'test/secret-keys/1.'.$keylist.'.test' );
 
     return file_match( $outfile, @files_to_test );

--- a/t/taint_mode.t
+++ b/t/taint_mode.t
@@ -16,7 +16,7 @@ my $gnupg;
 # See that we instantiate an object in Taint mode
 TEST
 {
-    $gnupg = GnuPG::Interface->new( call => '/usr/bin/gpg' );
+    $gnupg = GnuPG::Interface->new( call => './test/fake-gpg-v2' );
 };
 
 # See that version is set

--- a/test/secret-keys/1.2.2.test
+++ b/test/secret-keys/1.2.2.test
@@ -4,7 +4,7 @@ sec   dsa1024 2000-02-06 [SCA]
       93AFC4B1B0288A104996B44253AE596EF950DA9C
 uid           [ unknown] GnuPG test key (for testing purposes only)
 uid           [ unknown] Foo Bar (1)
-ssb   elg768 2000-02-06 [ER]
+ssb   elg768 2000-02-06 [E]
 
 sec   rsa2048 2016-10-12 [SC]
       278F850AA702911F1318F0A61B913CE9B6747DDC


### PR DESCRIPTION
A few new flags were added to gpg 2.3.8+, and the new "R" flag(Restricted encryption) broke tests.

See also gnupg commit 0988e49c45.