### PR TITLE
Handle versions of GnuPG 2.2.x that report the RENC key usage flag

### DIFF
--- a/t/MyTestSpecific.pm
+++ b/t/MyTestSpecific.pm
@@ -167,4 +167,16 @@ sub get_expired_test_sig_params {
     return %sig_params
 }
 
+# determine whether this GnuPG version reports on the "RENC" key usage
+# flag, which was added in 2.3.8 and 2.2.42 (see upstream
+# e4f61df8509e7aff0628971d9ea8fe967cd0f416)
+sub get_supported_renc {
+  my $gnupg = shift;
+  my $version = $gnupg->version;
+
+  return (($gnupg->cmp_version($version, '2.3.8') >= 0) ||
+          (($gnupg->cmp_version($version, '2.3') < 0) &&
+           ($gnupg->cmp_version($version, '2.2.42') >= 0)));
+}
+
 1;

--- a/t/get_public_keys.t
+++ b/t/get_public_keys.t
@@ -181,7 +181,7 @@ TEST
         hex_id                   => 'ADB99D9C2E854A6B',
         creation_date            => 949813119,
         creation_date_string     => '2000-02-06',
-        usage_flags              => $gnupg->cmp_version($gnupg->version, '2.3.8') >= 0 ? 'er' : 'e',
+        usage_flags              => get_supported_renc($gnupg) ? 'er' : 'e',
         pubkey_data              => $subkey_pub_data,
       );
 

--- a/t/get_secret_keys.t
+++ b/t/get_secret_keys.t
@@ -87,7 +87,7 @@ TEST
         hex_id                   => 'ADB99D9C2E854A6B',
         creation_date            => 949813119,
         creation_date_string     => '2000-02-06',
-        usage_flags              => $gnupg->cmp_version($gnupg->version, '2.3.8') >= 0 ? 'er' : 'e',
+        usage_flags              => get_supported_renc($gnupg) ? 'er' : 'e',
         pubkey_data              => $subkey_pub_data,
       };
 

--- a/t/list_secret_keys.t
+++ b/t/list_secret_keys.t
@@ -51,11 +51,11 @@ TEST
     elsif ( $gnupg->cmp_version( $gnupg->version, '2.1.11' ) <= 0 ) {
         $keylist = '1';
     }
-    elsif ( $gnupg->cmp_version( $gnupg->version, '2.3.8' ) < 0 ) {
-        $keylist = '2.2';
+    elsif ( get_supported_renc( $gnupg ) ) {
+        $keylist = '2';
     }
     else {
-        $keylist = '2';
+        $keylist = '2.2';
     }
 
 


### PR DESCRIPTION
GnuPG Upstream has apparently backported work on the putative "RENC" flag to the 2.2.x branch, i think as of 2.2.42.

This means that the output of key listings that have this flag set will change.  That breaks the fairly britle parser we have here.