### PR TITLE
Accept ? or ! or % as validity for expired/invalid sigs (see T7547)

### DIFF
--- a/t/MyTestSpecific.pm
+++ b/t/MyTestSpecific.pm
@@ -158,7 +158,7 @@ sub get_expired_test_sig_params {
     );
     if ($gnupg->cmp_version($gnupg->version, '2.2') > 0) {
         $sig_params{user_id_string} = '';
-        $sig_params{validity} = '?';
+        $sig_params{validity} = '?!';
     }
     else {
         $sig_params{user_id_string} = 'Frank J. Tobin <ftobin@neverending.org>',

--- a/t/get_public_keys.t
+++ b/t/get_public_keys.t
@@ -232,7 +232,6 @@ TEST
         }
 
         my @compared_fields = qw(
-                                    validity
                                     algo_num
                                     hex_id
                                     date
@@ -244,6 +243,11 @@ TEST
         foreach my $field ( @compared_fields ) {
             return 0 unless $self->$field eq $other->$field;
         }
+        return 0 unless $self->validity eq $other->validity ||
+          ($self->validity eq '?!' &&
+           ($other->validity eq '!' ||
+            $other->validity eq '?' ||
+            $other->validity eq '%'));
         # check for expiration if present?
         return 0 unless (defined $self->expiration_date) == (defined $other->expiration_date);
         if (defined $self->expiration_date) {


### PR DESCRIPTION
https://dev.gnupg.org/T7547 contains discussion about shifting expectations for the validity field for expired signatures.

In 2.4, which considers these expired signatures using SHA1 as too weak, it emits '%' for the validity field.

For flexibility, accept all three variants, in accordance with GnuPG upstream wishes.